### PR TITLE
Adding additional check for "fields" key

### DIFF
--- a/bin/tenable_io_audit.py
+++ b/bin/tenable_io_audit.py
@@ -107,7 +107,7 @@ class Input(Script):
                 if(timestamp > start):
                     end = max(end,timestamp)
                     count = count + 1
-                    if "fields" in event:
+                    if "fields" in event and event["fields"]:
                         fields = {}
                         for x in event["fields"]:
                             fields[x["key"]] = x["value"]


### PR DESCRIPTION
If the event has a "fields" key, but "fields" is None, this will cause an error. Added additional validation that fields has a value.

Example:
{'id': '[REDACTED]', 'action': 'audit.log.view', 'crud': 'r', 'actor': {'id': 'REDACTED', 'name': 'REDACTED'}, 'target': {'id': None, 'name': None, 'type': None}, 'description': 'GET /audit-log/v1/events', 'is_anonymous': None, 'is_failure': None, 'fields': None, 'received': '2025-04-04T00:01:32.601Z'}